### PR TITLE
Fix GitHub Pages 404 error with custom domain configuration

### DIFF
--- a/.github/workflows/custom-domain.yml
+++ b/.github/workflows/custom-domain.yml
@@ -1,0 +1,47 @@
+name: Configure Custom Domain
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - 'CNAME'
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  configure-custom-domain:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        with:
+          enablement: true
+      
+      - name: Ensure CNAME file exists
+        run: |
+          echo "lemonademap.com" > CNAME
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add CNAME
+          git commit -m "Update CNAME file for custom domain" || echo "No changes to commit"
+          git push
+      
+      - name: Update GitHub Pages settings
+        run: |
+          # This step is informational only as API permissions are limited
+          echo "Please manually verify the GitHub Pages settings in the repository:"
+          echo "1. Go to Settings > Pages"
+          echo "2. Ensure the source is set to 'Deploy from a branch'"
+          echo "3. Ensure the branch is set to 'gh-pages' and the folder is set to '/ (root)'"
+          echo "4. Ensure 'Custom domain' is set to 'lemonademap.com'"
+          echo "5. Ensure 'Enforce HTTPS' is checked"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,22 @@ jobs:
           branch: gh-pages
           clean: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Ensure CNAME file exists in gh-pages branch
+        run: |
+          # Clone the gh-pages branch
+          git clone --single-branch --branch gh-pages https://github.com/${{ github.repository }} gh-pages-temp
+          cd gh-pages-temp
+          
+          # Create or update CNAME file
+          echo "lemonademap.com" > CNAME
+          
+          # Commit and push changes
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add CNAME
+          git commit -m "Update CNAME file for custom domain" || echo "No changes to commit"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
 
       - name: Verify GitHub Pages Configuration
         run: |

--- a/.github/workflows/gh-pages-config.yml
+++ b/.github/workflows/gh-pages-config.yml
@@ -27,14 +27,20 @@ jobs:
 <head>
   <meta charset="utf-8">
   <title>Redirecting to Lemonade Map</title>
-  <script>window.location.href = "./lemonade-map/";</script>
+  <script>window.location.href = "/";</script>
 </head>
 <body>
   <p>
     If you are not redirected automatically, follow this
-    <a href="./lemonade-map/">link to the Lemonade Map application</a>.
+    <a href="/">link to the Lemonade Map application</a>.
   </p>
 </body>
 </html>
 EOF
           fi
+          
+      # Ensure CNAME file exists
+      - name: Verify CNAME file
+        run: |
+          echo "lemonademap.com" > CNAME
+          echo "Created CNAME file with domain: lemonademap.com"

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-https://lemonademap.com/
+lemonademap.com

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8">
   <title>Redirecting to Lemonade Map</title>
   <script>
-    window.location.href = "./lemonade-map/";
+    window.location.href = "/";
   </script>
 </head>
 <body>
-  <p>If you are not redirected automatically, follow this <a href="./lemonade-map/">link to the Lemonade Map application</a>.</p>
+  <p>If you are not redirected automatically, follow this <a href="/">link to the Lemonade Map application</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## Description

This PR fixes the GitHub Pages 404 error when accessing https://lemonademap.com/ by properly configuring the custom domain.

### Changes Made

1. Fixed the CNAME file in the root directory to contain only the domain name without protocol or trailing slash
2. Updated the GitHub Actions workflows to ensure the CNAME file is properly created and maintained in the gh-pages branch
3. Added a new workflow specifically for custom domain configuration
4. Updated the root index.html to use absolute paths instead of relative paths for redirects
5. Ensured all redirects point to the root path ("/") instead of a subdirectory

### Testing

After merging this PR, please verify that:
1. The GitHub Pages site is properly deployed
2. The custom domain is correctly configured
3. Accessing https://lemonademap.com/ shows the application instead of a 404 error

### Manual Steps Required

After merging, please check the repository settings:
1. Go to Settings > Pages
2. Ensure the source is set to "Deploy from a branch"
3. Ensure the branch is set to "gh-pages" and the folder is set to "/ (root)"
4. Verify that "Custom domain" is set to "lemonademap.com"
5. Ensure "Enforce HTTPS" is checked