### PR TITLE
Remove custom domain for GitHub Pages troubleshooting

### DIFF
--- a/.github/workflows/custom-domain.yml
+++ b/.github/workflows/custom-domain.yml
@@ -1,12 +1,10 @@
-name: Configure Custom Domain
+name: Configure GitHub Pages
 
 on:
   workflow_dispatch:
   push:
     branches:
       - gh-pages
-    paths:
-      - 'CNAME'
 
 permissions:
   contents: write
@@ -14,7 +12,7 @@ permissions:
   id-token: write
 
 jobs:
-  configure-custom-domain:
+  configure-github-pages:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
@@ -27,10 +25,8 @@ jobs:
         with:
           enablement: true
       
-      - name: Ensure CNAME file exists
+      - name: Ensure GitHub Pages files exist
         run: |
-          echo "lemonademap.com" > CNAME
-          
           # Create .nojekyll file to disable Jekyll processing
           touch .nojekyll
           
@@ -42,12 +38,12 @@ jobs:
 <head>
   <meta charset="utf-8">
   <title>Lemonade Map</title>
-  <meta http-equiv="refresh" content="0;url=/" />
+  <meta http-equiv="refresh" content="0;url=/Lemonade-Map/" />
 </head>
 <body>
   <p>
     If you are not redirected automatically, follow this
-    <a href="/">link to the Lemonade Map application</a>.
+    <a href="/Lemonade-Map/">link to the Lemonade Map application</a>.
   </p>
 </body>
 </html>
@@ -61,8 +57,8 @@ EOF
           
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add CNAME index.html .nojekyll 404.html || git add CNAME index.html .nojekyll
-          git commit -m "Update custom domain configuration" || echo "No changes to commit"
+          git add index.html .nojekyll 404.html
+          git commit -m "Update GitHub Pages configuration" || echo "No changes to commit"
           git push
       
       - name: Update GitHub Pages settings
@@ -72,5 +68,3 @@ EOF
           echo "1. Go to Settings > Pages"
           echo "2. Ensure the source is set to 'Deploy from a branch'"
           echo "3. Ensure the branch is set to 'gh-pages' and the folder is set to '/ (root)'"
-          echo "4. Ensure 'Custom domain' is set to 'lemonademap.com'"
-          echo "5. Ensure 'Enforce HTTPS' is checked"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,49 +101,13 @@ jobs:
           clean: true
           token: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Ensure CNAME file exists in gh-pages branch
+      - name: Ensure 404.html exists in dist directory
         run: |
-          # Create CNAME file in the dist directory before deployment
-          echo "lemonademap.com" > lemonade-map/dist/CNAME
-          
           # Create or update 404.html in the dist directory
           cp lemonade-map/public/404.html lemonade-map/dist/404.html
           
-          # Clone the gh-pages branch
-          git clone --single-branch --branch gh-pages https://github.com/${{ github.repository }} gh-pages-temp || mkdir -p gh-pages-temp
-          cd gh-pages-temp
-          
-          # Create or update CNAME file
-          echo "lemonademap.com" > CNAME
-          
-          # Create or update index.html if it doesn't exist
-          if [ ! -f "index.html" ]; then
-            cat << 'EOF' > index.html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Lemonade Map</title>
-  <meta http-equiv="refresh" content="0;url=/" />
-</head>
-<body>
-  <p>
-    If you are not redirected automatically, follow this
-    <a href="/">link to the Lemonade Map application</a>.
-  </p>
-</body>
-</html>
-EOF
-          fi
-          
-          # Commit and push changes if gh-pages branch exists
-          if [ -d ".git" ]; then
-            git config user.name "GitHub Actions Bot"
-            git config user.email "actions@github.com"
-            git add CNAME index.html
-            git commit -m "Update CNAME file for custom domain" || echo "No changes to commit"
-            git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages || echo "Failed to push to gh-pages branch"
-          fi
+          # Create .nojekyll file to disable Jekyll processing
+          touch lemonade-map/dist/.nojekyll
 
       - name: Verify GitHub Pages Configuration
         run: |

--- a/.github/workflows/gh-pages-config.yml
+++ b/.github/workflows/gh-pages-config.yml
@@ -36,12 +36,12 @@ jobs:
 <head>
   <meta charset="utf-8">
   <title>Lemonade Map</title>
-  <meta http-equiv="refresh" content="0;url=/" />
+  <meta http-equiv="refresh" content="0;url=/Lemonade-Map/" />
 </head>
 <body>
   <p>
     If you are not redirected automatically, follow this
-    <a href="/">link to the Lemonade Map application</a>.
+    <a href="/Lemonade-Map/">link to the Lemonade Map application</a>.
   </p>
 </body>
 </html>
@@ -50,12 +50,6 @@ EOF
           
           # Create .nojekyll file to disable Jekyll processing
           touch .nojekyll
-          
-      # Ensure CNAME file exists
-      - name: Verify CNAME file
-        run: |
-          echo "lemonademap.com" > CNAME
-          echo "Created CNAME file with domain: lemonademap.com"
           
       # Commit changes if any were made
       - name: Commit changes

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -42,18 +42,14 @@ jobs:
           npm run build
 
       # Copy the root index.html redirect file to the dist directory
-      - name: Ensure correct index.html
+      - name: Ensure correct files in dist directory
         run: |
           # Make sure the dist directory exists
           mkdir -p lemonade-map/dist
           # Copy 404.html to the root of the dist directory
           cp lemonade-map/public/404.html lemonade-map/dist/
-          # Create CNAME file in the dist directory
-          echo "lemonademap.com" > lemonade-map/dist/CNAME
           # Create .nojekyll file to disable Jekyll processing
           touch lemonade-map/dist/.nojekyll
-          # No need for a redirect in index.html since we're using a custom domain with root path
-          # The main application index.html will be used directly
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/lemonade-map/package.json
+++ b/lemonade-map/package.json
@@ -2,7 +2,7 @@
   "name": "lemonade-map",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://lemonademap.com/",
+  "homepage": "https://beaux-riel.github.io/Lemonade-Map/",
   "dependencies": {
     "@supabase/supabase-js": "^2.39.7",
     "@testing-library/dom": "^10.4.0",

--- a/lemonade-map/public/404.html
+++ b/lemonade-map/public/404.html
@@ -22,8 +22,8 @@
     // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
     // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
     // Otherwise, leave pathSegmentsToKeep as 0.
-    // Since we're using a custom domain, we set this to 0
-    var pathSegmentsToKeep = 0;
+    // For GitHub Pages without a custom domain, set this to 1
+    var pathSegmentsToKeep = 1;
 
     var l = window.location;
     l.replace(

--- a/lemonade-map/vite.config.js
+++ b/lemonade-map/vite.config.js
@@ -9,18 +9,7 @@ const getBase = () => {
   // For GitHub Pages deployment via environment variable
   if (process.env.GITHUB_REPOSITORY) {
     const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-    // Check if we're using a custom domain by looking at the CNAME file
-    try {
-      const fs = require('fs');
-      if (fs.existsSync('./public/CNAME')) {
-        // For custom domain, use root path
-        return '/';
-      }
-      return `/${repo}/`;
-    } catch (e) {
-      console.warn('Error checking CNAME file:', e);
-      return `/${repo}/`;
-    }
+    return `/${repo}/`;
   }
   
   // For GitHub Pages deployment via package.json homepage
@@ -28,11 +17,6 @@ const getBase = () => {
     const packageJson = require('./package.json');
     if (packageJson.homepage) {
       const url = new URL(packageJson.homepage);
-      // Check if we're using a custom domain (not github.io)
-      if (!url.hostname.includes('github.io')) {
-        // For custom domain, use root path
-        return '/';
-      }
       const pathSegments = url.pathname.split('/').filter(Boolean);
       if (pathSegments.length > 0) {
         return `/${pathSegments.join('/')}/`;
@@ -42,18 +26,8 @@ const getBase = () => {
     console.warn('Could not parse homepage from package.json:', e);
   }
   
-  // For local development or custom domain
-  // Check if CNAME exists to determine if we're using a custom domain
-  try {
-    const fs = require('fs');
-    if (fs.existsSync('./public/CNAME')) {
-      return '/';
-    }
-  } catch (e) {
-    console.warn('Error checking CNAME file:', e);
-  }
-  
-  return '/Lemonade-map/';
+  // Default for GitHub Pages
+  return '/Lemonade-Map/';
 };
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
This PR removes the custom domain configuration to help troubleshoot GitHub Pages deployment issues. The following changes have been made:

1. Removed custom domain configuration (CNAME files)
2. Updated the base path in vite.config.js to use the repository path format (`/Lemonade-Map/`)
3. Updated package.json homepage to use GitHub Pages URL (`https://beaux-riel.github.io/Lemonade-Map/`)
4. Set pathSegmentsToKeep to 1 in 404.html for GitHub Pages without custom domain
5. Updated all workflows to remove CNAME configuration
6. Simplified the deployment process

These changes should allow us to deploy to GitHub Pages without the custom domain to troubleshoot the deployment issues.