### PR TITLE
Fix dashboard tabs and stand expiration logic

### DIFF
--- a/lemonade-map/src/pages/SellerDashboardPage.jsx
+++ b/lemonade-map/src/pages/SellerDashboardPage.jsx
@@ -202,17 +202,15 @@ const SellerDashboardPage = () => {
       
       {/* Tabs */}
       <Tabs
-        activeTab={activeTab}
-        onChange={setActiveTab}
-        tabs={[
-          { id: 'stands', label: 'My Stands' },
-          { id: 'products', label: 'My Products' }
-        ]}
+        defaultTab={activeTab === 'products' ? 1 : 0}
+        onChange={(index) => setActiveTab(index === 0 ? 'stands' : 'products')}
         className="mb-6"
-      />
-      
-      {/* Stands Tab */}
-      {activeTab === 'stands' && (
+      >
+        <Tabs.Item>My Stands</Tabs.Item>
+        <Tabs.Item>My Products</Tabs.Item>
+        
+        <Tabs.Panel>
+          {/* Stands Tab Content */}
         <div className="bg-white rounded-xl shadow-md p-6 mb-8">
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-2xl font-display text-lemonade-blue-dark">
@@ -281,10 +279,10 @@ const SellerDashboardPage = () => {
             </div>
           )}
         </div>
-      )}
-      
-      {/* Products Tab */}
-      {activeTab === 'products' && (
+        </Tabs.Panel>
+        
+        <Tabs.Panel>
+          {/* Products Tab Content */}
         <div className="bg-white rounded-xl shadow-md p-6 mb-8">
           <div className="flex justify-between items-center mb-6">
             <h2 className="text-2xl font-display text-lemonade-blue-dark">
@@ -415,7 +413,8 @@ const SellerDashboardPage = () => {
             </div>
           )}
         </div>
-      )}
+        </Tabs.Panel>
+      </Tabs>
       
       {/* Quick Edit Product Modal */}
       {quickEditProduct && (


### PR DESCRIPTION
This PR addresses three issues:

1. Fixes the issue that prevents the "stands" and "products" tabs from rendering on the seller dashboard
   - Updated the Tabs component implementation to use the correct pattern with Tabs.Item and Tabs.Panel components

2. Changes the stand expiration logic to expire at midnight on the day they were created
   - Modified the SQL functions to set the expiration time to 23:59:59 of the current day (midnight) instead of 00:00:00 of the next day
   - Updated all relevant functions to use the same logic

3. Adds a countdown timer to midnight on the active stand
   - Enhanced the StandExpirationInfo component to include a real-time countdown timer
   - Added useEffect and useState hooks to update the timer every second
   - Improved the UI to display the countdown in a more prominent way
   - Added seconds to the countdown for more precision, especially when close to expiration