### PR TITLE
Fix: Manage stand error when stand has no products

### DIFF
--- a/lemonade-map/src/api/supabaseApi.js
+++ b/lemonade-map/src/api/supabaseApi.js
@@ -165,9 +165,8 @@ export const getStands = async () => {
 export const getStandById = async (standId) => {
   const { data, error } = await supabase
     .from("stands")
-    .select("*, products!inner(*)")
+    .select("*, products(*)")
     .eq("id", standId)
-    .eq("products.stand_id", standId)
     .single();
   return { data, error };
 };


### PR DESCRIPTION
## Issue
When clicking "Manage" on the seller dashboard, users were faced with an error message: "Something went wrong. We're sorry, but an unexpected error occurred. Our team has been notified."

## Root Cause
The `getStandById` function in `supabaseApi.js` was using an inner join with the products table, which means it would only return stands that have associated products. If a stand didn't have any products, this query would fail and return an error.

## Fix
Changed the inner join (`!inner`) to a left join in the `getStandById` function, which will return the stand even if it doesn't have any products. This ensures that users can manage their stands regardless of whether they have products or not.