### PR TITLE
Fix: Add support for rendering children in Map component to enable DraggableMarker visibility

### DIFF
--- a/lemonade-map/src/components/map/Map.jsx
+++ b/lemonade-map/src/components/map/Map.jsx
@@ -300,6 +300,7 @@ const Map = ({
   onStandClick,
   onUserLocationFound,
   className = "",
+  children,
   ...props
 }) => {
   // Memoize the stands array to prevent unnecessary re-renders
@@ -358,6 +359,9 @@ const Map = ({
             onStandClick={onStandClick}
           />
         ))}
+        
+        {/* Render children components (like DraggableMarker) */}
+        {children}
       </MapContainer>
     </div>
   );
@@ -382,6 +386,7 @@ Map.propTypes = {
   onStandClick: PropTypes.func,
   onUserLocationFound: PropTypes.func,
   className: PropTypes.string,
+  children: PropTypes.node,
 };
 
 export default Map;


### PR DESCRIPTION
## Issue
When attempting to "Adjust Stand Location" users were unable to see the marker or drag it to the desired location.

## Root Cause
The Map component did not render its children, so the DraggableMarker component passed as a child to the Map in the StandDetailPage was not being displayed.

## Solution
1. Added `children` to the Map component props
2. Added rendering of children in the Map component
3. Updated PropTypes to include children

This fix ensures that when users attempt to adjust their stand location, they can now see and drag the marker to set the desired location.