### PR TITLE
Fix map location modal blank page issue

### DIFF
--- a/lemonade-map/src/components/map/DraggableMarker.jsx
+++ b/lemonade-map/src/components/map/DraggableMarker.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Marker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
@@ -17,6 +17,22 @@ const DraggableMarker = ({
   const markerRef = useRef(null);
   const map = useMap();
   const [markerPosition, setMarkerPosition] = useState(position);
+  
+  // Create a default icon if none is provided
+  const defaultIcon = useMemo(() => {
+    if (icon) return icon;
+    
+    // Create a custom draggable marker icon
+    return new L.Icon({
+      iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+      iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+      shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+      iconSize: [25, 41],
+      iconAnchor: [12, 41],
+      popupAnchor: [1, -34],
+      shadowSize: [41, 41]
+    });
+  }, [icon]);
 
   // Update marker position when the position prop changes
   useEffect(() => {
@@ -55,7 +71,7 @@ const DraggableMarker = ({
       eventHandlers={eventHandlers}
       position={markerPosition}
       ref={markerRef}
-      icon={icon}
+      icon={defaultIcon}
     >
       {popupContent && (
         <Popup>

--- a/lemonade-map/src/components/map/Map.jsx
+++ b/lemonade-map/src/components/map/Map.jsx
@@ -22,28 +22,34 @@ L.Browser.iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
 // This is needed because the default markers use relative paths that don't work in React
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
-  iconRetinaUrl: null,
-  iconUrl: null,
-  shadowUrl: null,
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
 });
 
 // Custom lemonade stand marker icon
-const createLemonadeIcon = () =>
-  new L.Icon({
-    iconUrl: "/images/markers/lemonade-marker.svg",
+const createLemonadeIcon = () => {
+  // Get the base URL from the window location
+  const baseUrl = window.location.origin;
+  return new L.Icon({
+    iconUrl: `${baseUrl}/images/markers/lemonade-marker.svg`,
     iconSize: [40, 48],
     iconAnchor: [20, 48],
     popupAnchor: [0, -48],
   });
+};
 
 // Custom user location marker icon
-const createUserLocationIcon = () =>
-  new L.Icon({
-    iconUrl: "/images/markers/user-location.svg",
+const createUserLocationIcon = () => {
+  // Get the base URL from the window location
+  const baseUrl = window.location.origin;
+  return new L.Icon({
+    iconUrl: `${baseUrl}/images/markers/user-location.svg`,
     iconSize: [24, 24],
     iconAnchor: [12, 12],
     popupAnchor: [0, -12],
   });
+};
 
 // Component to handle map view updates and iOS-specific fixes
 const MapViewUpdater = ({ center, zoom }) => {

--- a/lemonade-map/src/index.jsx
+++ b/lemonade-map/src/index.jsx
@@ -3,20 +3,31 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
 import reportWebVitals from './reportWebVitals';
+import 'leaflet/dist/leaflet.css';
 
 // Preload critical assets
 const preloadCriticalAssets = () => {
+  // Get the base URL from the window location
+  const baseUrl = window.location.origin;
+  
   // Preload main CSS
   const linkCss = document.createElement('link');
   linkCss.rel = 'preload';
   linkCss.as = 'style';
-  linkCss.href = '/styles/tailwind.css';
+  linkCss.href = `${baseUrl}/styles/tailwind.css`;
   document.head.appendChild(linkCss);
+  
+  // Preload Leaflet CSS
+  const leafletCss = document.createElement('link');
+  leafletCss.rel = 'preload';
+  leafletCss.as = 'style';
+  leafletCss.href = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css';
+  document.head.appendChild(leafletCss);
   
   // Preload critical fonts
   const fontUrls = [
-    '/fonts/lemonade-display.woff2',
-    '/fonts/lemonade-body.woff2'
+    `${baseUrl}/fonts/lemonade-display.woff2`,
+    `${baseUrl}/fonts/lemonade-body.woff2`
   ];
   
   fontUrls.forEach(url => {
@@ -25,6 +36,24 @@ const preloadCriticalAssets = () => {
     link.as = 'font';
     link.href = url;
     link.type = 'font/woff2';
+    link.crossOrigin = 'anonymous';
+    document.head.appendChild(link);
+  });
+  
+  // Preload marker icons
+  const markerUrls = [
+    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+    'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+    `${baseUrl}/images/markers/lemonade-marker.svg`,
+    `${baseUrl}/images/markers/user-location.svg`
+  ];
+  
+  markerUrls.forEach(url => {
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'image';
+    link.href = url;
     link.crossOrigin = 'anonymous';
     document.head.appendChild(link);
   });


### PR DESCRIPTION
## Issue Fixed

When a user clicks "Set Location on Map (Drag & Drop)" when editing a stand, they were being directed to a blank page.

## Changes Made

1. Fixed the Leaflet marker icons configuration:
   - Updated the L.Icon.Default.mergeOptions to use CDN URLs for the marker icons instead of null values
   - This ensures that the default markers are properly displayed on the map

2. Fixed the custom marker icons to use absolute paths:
   - Modified the createLemonadeIcon and createUserLocationIcon functions to use window.location.origin to get the base URL
   - This ensures that the custom marker icons are properly loaded regardless of the deployment environment

3. Added proper Leaflet CSS import:
   - Added an explicit import of "leaflet/dist/leaflet.css" in the index.jsx file
   - Added preloading of Leaflet CSS and marker icons in the preloadCriticalAssets function

4. Enhanced the DraggableMarker component:
   - Added a useMemo hook to create a default icon if none is provided
   - Updated the Marker component to use the defaultIcon instead of the potentially undefined icon prop
   - This ensures that the draggable marker is always visible on the map

These changes address the root cause of the issue, which was that the Leaflet map was not properly loading the marker icons and CSS, resulting in a blank page when users tried to set a location on the map.