### PR TITLE
Fix map recentering and zoom reset issues

### DIFF
--- a/lemonade-map/src/components/map/MapPage.tsx
+++ b/lemonade-map/src/components/map/MapPage.tsx
@@ -65,18 +65,11 @@ const MapPage: React.FC<MapPageProps> = ({
   const handleUserLocationFound = (latlng: { lat: number; lng: number }) => {
     if (!latlng) return;
     
-    // Only update map center if:
-    // 1. This is the first location update (initial centering)
-    // 2. The user has explicitly requested to center on their location
-    // 3. The location has changed significantly (more than ~100 meters)
-    const isSignificantChange = 
-      Math.abs(mapCenter[0] - latlng.lat) > 0.001 || 
-      Math.abs(mapCenter[1] - latlng.lng) > 0.001;
-      
-    // Use a ref to track if this is the first location update
+    // Only update map center if this is the first location update (initial centering)
+    // We no longer recenter on significant changes to prevent disrupting user navigation
     const isFirstLocationUpdate = !location;
     
-    if (isFirstLocationUpdate || isSignificantChange) {
+    if (isFirstLocationUpdate) {
       setMapCenter([latlng.lat, latlng.lng]);
     }
   };


### PR DESCRIPTION
This PR fixes the issue where the map component on the home page keeps recentering and resetting the zoom when the user is sharing their location.

### Changes made:

1. Modified the UserLocationMarker component to only notify the parent component once when the location is first detected
2. Updated the MapPage component to only center the map on the user location during initial render
3. Enhanced the MapViewUpdater component to prevent view resets during location updates
4. Added user interaction tracking to distinguish between programmatic updates and user-initiated changes

These changes ensure that:
- The map centers on the user location only once when it first loads
- Subsequent location updates do not cause the map to recenter
- User interactions with the map (panning, zooming) are preserved
- The map does not reset its view when the user location updates